### PR TITLE
Modernize for current Clojure/JDK: fix JDK 11+ build, add CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report incorrect or unexpected behavior
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Description**
+A clear description of what the bug is.
+
+**To reproduce**
+A minimal code snippet or REPL session that triggers the problem:
+
+```clojure
+;; ...
+```
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior**
+What actually happened (include the full error / stack trace if any).
+
+**Environment**
+- Library version:
+- Clojure version:
+- JDK version:
+- OS:
+
+**Additional context**
+Anything else that might help.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an enhancement or new capability
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**What problem does this solve?**
+The use case or limitation motivating the request.
+
+**Proposed solution**
+What you'd like the library to do. API sketch welcome:
+
+```clojure
+;; ...
+```
+
+**Alternatives considered**
+Other approaches you've thought about or worked around.
+
+**Additional context**
+Links, references, or prior art (specs, standards, other libraries).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!-- Keep each pull request to one logical change. -->
+
+**What does this change?**
+A short summary of the change and why it's needed. Link any related issue
+(`Closes #123`).
+
+**Checklist**
+
+- [ ] Tests added or updated (a regression test for bug fixes)
+- [ ] `lein test` passes
+- [ ] `lein check` is free of reflection warnings
+- [ ] `CHANGES.md` / `CHANGELOG.md` updated if the change is user-visible
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -3,7 +3,7 @@ name: deps
 # Weekly dependency check via antq (https://github.com/liquidz/antq).
 # antq natively reads project.clj, deps.edn, and bb.edn, so it covers Leiningen
 # and tools.deps projects uniformly. GitHub Actions pins are intentionally left
-# to a separate process (--skip=github-action) since the default token cannot
+# to a separate process (--skip=github-action --exclude org.clojure/clojure) since the default token cannot
 # push workflow-file changes.
 #
 # This job only pushes a branch (contents: write) and links to the compare page.
@@ -32,7 +32,7 @@ jobs:
       - name: Upgrade outdated dependencies
         run: >
           clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "2.11.1276"}}}'
-          -M -m antq.core --upgrade --force --skip=github-action
+          -M -m antq.core --upgrade --force --skip=github-action --exclude org.clojure/clojure
       - name: Push branch and link to a pull request
         run: |
           if [ -z "$(git status --porcelain)" ]; then

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,14 +1,8 @@
 name: deps
 
 # Weekly dependency check via antq (https://github.com/liquidz/antq).
-# antq natively reads project.clj, deps.edn, and bb.edn, so it covers Leiningen
-# and tools.deps projects uniformly. GitHub Actions pins are intentionally left
-# to a separate process (--skip=github-action --exclude org.clojure/clojure) since the default token cannot
-# push workflow-file changes.
-#
-# This job only pushes a branch (contents: write) and links to the compare page.
-# It never calls the pull-request API, so GitHub Actions is NOT granted the
-# "create and approve pull requests" capability.
+# antq natively reads project.clj, deps.edn, and bb.edn, and the GitHub Actions
+# pins below, so it covers Leiningen and tools.deps projects uniformly.
 on:
   schedule:
     - cron: '23 6 * * 1'   # Mondays 06:23 UTC
@@ -16,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   antq:
@@ -33,24 +28,16 @@ jobs:
         run: >
           clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "2.11.1276"}}}'
           -M -m antq.core --upgrade --force --skip=github-action --exclude org.clojure/clojure
-      - name: Push branch and link to a pull request
-        run: |
-          if [ -z "$(git status --porcelain)" ]; then
-            echo 'All dependencies up to date.' >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git checkout -B deps/antq
-          git commit -am 'chore(deps): bump outdated dependencies'
-          git push -f origin deps/antq
-          {
-            echo '### Dependency upgrades available';
-            echo '';
-            echo "Pushed branch \`deps/antq\`. Open a pull request:";
-            echo "https://github.com/${{ github.repository }}/pull/new/deps/antq";
-            echo '';
-            echo '```diff';
-            git --no-pager diff 'HEAD~1' --stat;
-            echo '```';
-          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: deps/antq
+          delete-branch: true
+          commit-message: 'chore(deps): bump outdated dependencies'
+          title: 'chore(deps): bump outdated dependencies'
+          body: |
+            Automated dependency check by [antq](https://github.com/liquidz/antq).
+
+            Review the bumps, confirm CI is green, then merge. Major upgrades may
+            need manual validation before merging.
+          labels: dependencies

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,0 +1,43 @@
+name: deps
+
+# Weekly dependency check via antq (https://github.com/liquidz/antq).
+# antq natively reads project.clj, deps.edn, and bb.edn, and the GitHub Actions
+# pins below, so it covers Leiningen and tools.deps projects uniformly.
+on:
+  schedule:
+    - cron: '23 6 * * 1'   # Mondays 06:23 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  antq:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          cli: latest
+      - name: Upgrade outdated dependencies
+        run: >
+          clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "2.11.1276"}}}'
+          -M -m antq.core --upgrade --force
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: deps/antq
+          delete-branch: true
+          commit-message: 'chore(deps): bump outdated dependencies'
+          title: 'chore(deps): bump outdated dependencies'
+          body: |
+            Automated dependency check by [antq](https://github.com/liquidz/antq).
+
+            Review the bumps, confirm CI is green, then merge. Major upgrades may
+            need manual validation before merging.
+          labels: dependencies

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,8 +1,14 @@
 name: deps
 
 # Weekly dependency check via antq (https://github.com/liquidz/antq).
-# antq natively reads project.clj, deps.edn, and bb.edn, and the GitHub Actions
-# pins below, so it covers Leiningen and tools.deps projects uniformly.
+# antq natively reads project.clj, deps.edn, and bb.edn, so it covers Leiningen
+# and tools.deps projects uniformly. GitHub Actions pins are intentionally left
+# to a separate process (--skip=github-action) since the default token cannot
+# push workflow-file changes.
+#
+# This job only pushes a branch (contents: write) and links to the compare page.
+# It never calls the pull-request API, so GitHub Actions is NOT granted the
+# "create and approve pull requests" capability.
 on:
   schedule:
     - cron: '23 6 * * 1'   # Mondays 06:23 UTC
@@ -10,7 +16,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   antq:
@@ -28,16 +33,24 @@ jobs:
         run: >
           clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "2.11.1276"}}}'
           -M -m antq.core --upgrade --force --skip=github-action
-      - name: Open pull request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          branch: deps/antq
-          delete-branch: true
-          commit-message: 'chore(deps): bump outdated dependencies'
-          title: 'chore(deps): bump outdated dependencies'
-          body: |
-            Automated dependency check by [antq](https://github.com/liquidz/antq).
-
-            Review the bumps, confirm CI is green, then merge. Major upgrades may
-            need manual validation before merging.
-          labels: dependencies
+      - name: Push branch and link to a pull request
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo 'All dependencies up to date.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -B deps/antq
+          git commit -am 'chore(deps): bump outdated dependencies'
+          git push -f origin deps/antq
+          {
+            echo '### Dependency upgrades available';
+            echo '';
+            echo "Pushed branch \`deps/antq\`. Open a pull request:";
+            echo "https://github.com/${{ github.repository }}/pull/new/deps/antq";
+            echo '';
+            echo '```diff';
+            git --no-pager diff 'HEAD~1' --stat;
+            echo '```';
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Upgrade outdated dependencies
         run: >
           clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "2.11.1276"}}}'
-          -M -m antq.core --upgrade --force
+          -M -m antq.core --upgrade --force --skip=github-action
       - name: Open pull request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: release
+
+# Publishes to Clojars when a v* tag is pushed. The tag is the deliberate
+# "this is worth a release" signal; nothing publishes on ordinary commits.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch: {}   # manual run for testing (skips the tag-version guard)
+
+permissions:
+  contents: write          # create the GitHub Release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          lein: 2.12.0
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('project.clj') }}
+          restore-keys: ${{ runner.os }}-m2-
+
+      - name: Verify tag matches project.clj version
+        if: github.ref_type == 'tag'
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PROJ=$(sed -n '1s/[^"]*"\([0-9][^"]*\)".*/\1/p' project.clj)
+          echo "tag=$TAG project.clj=$PROJ"
+          if [ "$TAG" != "$PROJ" ]; then
+            echo "::error::tag v$TAG does not match project.clj version $PROJ"
+            exit 1
+          fi
+
+      - name: Test
+        run: lein test
+
+      - name: Deploy to Clojars
+        env:
+          CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+          CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
+        run: lein deploy clojars
+
+      - name: Create GitHub Release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [ '8', '11', '17', '21' ]
+        clojure: [ 'clojure-1-10', 'clojure-1-11', 'clojure-1-12' ]
+    name: JDK ${{ matrix.jdk }} / ${{ matrix.clojure }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.jdk }}
+      - name: Set up Leiningen
+        uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          lein: 2.12.0
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('project.clj') }}
+          restore-keys: ${{ runner.os }}-m2-
+      - name: Run tests
+        run: lein with-profile +${{ matrix.clojure }} test

--- a/.lein-repl-history
+++ b/.lein-repl-history
@@ -1,0 +1,7 @@
+(require (quote [hier-set.core :as hs :refer [hier-set]]))
+(def sw? #(.startsWith %2 %1))
+(def h (hier-set sw? "ack" "foo" "foo.bar" "quux"))
+(println "get foo.bar.baz =>" (get h "foo.bar.baz"))
+(println "ancestors foo.baz =>" (hs/ancestors h "foo.baz"))
+(println "descendants foo =>" (hs/descendants h "foo"))
+(println "get bar =>" (get h "bar"))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,38 @@
+# Changes
+
+## 1.2.0
+
+Maintenance/modernization release (fork).
+
+- **Compatibility with modern JDKs.** Hinted the `toArray(T[])` method so the
+  type compiles on JDK 11 and later; it had been broken since Java 11 added
+  `Collection.toArray(IntFunction)`, which made the single-argument `toArray`
+  overload ambiguous.
+- Target Clojure 1.12.5; replaced the EOL 1.4/1.5/1.6 test profiles with
+  1.10.3 / 1.11.4 / 1.12.5.
+- Added GitHub Actions CI: JDK 8/11/17/21 × Clojure 1.10.3/1.11.4/1.12.5.
+- Removed the unused `ILookup` import.
+- Expanded the test suite from 30 to 61 assertions (comparator, metadata,
+  `java.util.Set` and `Sorted` interop, not-found semantics, immutability).
+- Added `:min-lein-version` and `:pedantic? :warn`.
+
+Known issue (pre-existing, unchanged): `hashCode` uses Clojure's hash rather
+than `java.util.Set`'s sum-of-element-hashCodes contract, so a `HierSet` and an
+equal `java.util.HashSet` may report different hash codes.
+
+## 1.1.2
+
+- Fixed a bad `pom.xml`.
+
+## 1.1.1
+
+- Fixed an infinite-recursion bug in `HierSet`'s `equals` method.
+
+## 1.1.0
+
+- Implemented the persistent/`java.util.Set` interfaces; added `conj`/`disj`
+  support and tests.
+
+## 1.0.0
+
+- Initial release.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@ Maintenance/modernization release (fork).
   type compiles on JDK 11 and later; it had been broken since Java 11 added
   `Collection.toArray(IntFunction)`, which made the single-argument `toArray`
   overload ambiguous.
+- **Correct `java.util.Set` hash code.** `hashCode` now returns the sum of the
+  members' hash codes, as the `Set` contract requires, so a `HierSet` and an
+  equal `java.util.HashSet` hash identically. It previously used Clojure's
+  collection hash, breaking the contract.
 - Target Clojure 1.12.5; replaced the EOL 1.4/1.5/1.6 test profiles with
   1.10.3 / 1.11.4 / 1.12.5.
 - Added GitHub Actions CI: JDK 8/11/17/21 × Clojure 1.10.3/1.11.4/1.12.5.
@@ -15,10 +19,6 @@ Maintenance/modernization release (fork).
 - Expanded the test suite from 30 to 61 assertions (comparator, metadata,
   `java.util.Set` and `Sorted` interop, not-found semantics, immutability).
 - Added `:min-lein-version` and `:pedantic? :warn`.
-
-Known issue (pre-existing, unchanged): `hashCode` uses Clojure's hash rather
-than `java.util.Set`'s sum-of-element-hashCodes contract, so a `HierSet` and an
-equal `java.util.HashSet` may report different hash codes.
 
 ## 1.1.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Changes
 
+## 1.2.1
+
+Docs and build-config release.
+
+- Standardize the README to the canonical skeleton; add Clojars and cljdoc
+  badges; fix the install coordinate, document deps.edn usage, and repair the
+  example.
+- Move the Clojars deploy config to the global Leiningen profile (no consumer
+  impact).
+
 ## 1.2.0
 
 Maintenance/modernization release (fork).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,72 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+jsavyasachi@gmail.com. All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to hier-set
+
+Thanks for your interest in improving `hier-set`. Bug reports, fixes, and
+focused feature contributions are all welcome.
+
+## Before you start
+
+- For anything beyond a trivial fix, **open an issue first** so we can agree on
+  the approach before you invest time.
+- Check existing issues and pull requests to avoid duplicate work.
+
+## Development
+
+This is a Clojure library. You need a JDK and [Leiningen](https://leiningen.org/)
+(projects that have migrated to `deps.edn` use the Clojure CLI instead — see the
+README).
+
+```bash
+lein test     # run the test suite
+lein check    # AOT-compile; must be free of reflection warnings
+```
+
+The bar for a mergeable change:
+
+- **Tests first.** Add or update tests for the behavior you change; for a bug
+  fix, include a regression test that fails before your fix and passes after.
+- **Green build.** `lein test` passes and `lein check` reports **zero**
+  reflection warnings.
+- **No scope creep.** Keep each pull request to one logical change.
+
+## Commits and pull requests
+
+- Follow [Conventional Commits](https://www.conventionalcommits.org/)
+  (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:` …).
+- Keep the subject in the imperative mood and under ~72 characters.
+- Update `CHANGES.md` / `CHANGELOG.md` when your change is user-visible.
+- Rebase on the latest `main` before opening the pull request.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+same license as this project (see `LICENSE` / the README).

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ multiple inheritance.
 Leiningen (`project.clj`):
 
 ```clj
-[net.clojars.savya/hier-set "1.2.0"]
+[net.clojars.savya/hier-set "1.2.1"]
 ```
 
 Clojure CLI (`deps.edn`):
 
 ```clj
-net.clojars.savya/hier-set {:mvn/version "1.2.0"}
+net.clojars.savya/hier-set {:mvn/version "1.2.1"}
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -25,11 +25,16 @@ multiple inheritance.
 
 ## Usage
 
-Add `hier-set` to the `:dependencies` list in your
-[Leiningen](https://github.com/technomancy/leiningen) `project.clj`:
+Leiningen/Boot (`project.clj`):
 
 ```clj
-[hier-set "1.2.0"]
+[net.clojars.savya/hier-set "1.2.0"]
+```
+
+Clojure CLI/`deps.edn`:
+
+```clj
+net.clojars.savya/hier-set {:mvn/version "1.2.0"}
 ```
 
 Primary usage is then through the `hier-set` and `hier-set-by` constructor
@@ -49,19 +54,18 @@ A trivial example:
 
 ```clj
 (ns example.hier-set
-  (:require [hier-set.core :as hs])
-  (:use [hier-set.core :only [hier-set]])
+  (:require [hier-set.core :as hs :refer [hier-set]]))
 
-(def with-starts? #(.startsWith %2 %1))
+(def starts-with? #(.startsWith %2 %1))
 
-(def hs (hier-set with-starts? "ack" "foo" "foo.bar" "quux")
+(def h (hier-set starts-with? "ack" "foo" "foo.bar" "quux"))
 
-(get hs "bar")              ;;=> nil
-(get hs "foo")              ;;=> ("foo")
-(get hs "foo.bar.baz")      ;;=> ("foo.bar" "foo")
-(hs/ancestors hs "bar")     ;;=> ()
-(hs/ancestors hs "foo.baz") ;;=> ("foo")
-(hs/descendants hs "foo")   ;;=> ("foo" "foo.bar")
+(get h "bar")              ;;=> nil
+(get h "foo")              ;;=> ("foo")
+(get h "foo.bar.baz")      ;;=> ("foo.bar" "foo")
+(hs/ancestors h "bar")     ;;=> ()
+(hs/ancestors h "foo.baz") ;;=> ("foo")
+(hs/descendants h "foo")   ;;=> ("foo" "foo.bar")
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@
 [![cljdoc](https://cljdoc.org/badge/net.clojars.savya/hier-set)](https://cljdoc.org/d/net.clojars.savya/hier-set/CURRENT)
 [![test](https://github.com/jsavyasachi/hier-set/actions/workflows/test.yml/badge.svg)](https://github.com/jsavyasachi/hier-set/actions/workflows/test.yml)
 
-Library providing a "hierarchical set" data structure.  The provided data
-structure is set of elements with a defined hierarchical relationship.  An
-element is considered to be in the set either if it is provided as a primary
-set member or if it is a descendant of any such element.  Lookup in the set not
-only determines set membership, but also finds all primary set members which
-are ancestors of the lookup element.
+A "hierarchical set" data structure for Clojure: a set of elements with a
+defined hierarchical relationship, where an element is a member if it is a
+primary member or a descendant of one. Lookup returns set membership *and* all
+primary members that are ancestors of the lookup element.
+
+## Stack
+
+<a href="https://clojure.org"><img src="https://img.shields.io/badge/Clojure-5881D8?style=flat&logo=clojure&logoColor=fff" alt="Clojure" /></a>
+
+## Why
 
 The hierarchical relationship is defined by the element sort-order and a
 separate containment predicate, with the following constraints:
@@ -24,19 +28,21 @@ hierarchical filesystems, or IP networks.  It is inappropriate for modeling
 complex, ad hoc hierarchies, such as the relationships between classes with
 multiple inheritance.
 
-## Usage
+## Installation
 
-Leiningen/Boot (`project.clj`):
+Leiningen (`project.clj`):
 
 ```clj
 [net.clojars.savya/hier-set "1.2.0"]
 ```
 
-Clojure CLI/`deps.edn`:
+Clojure CLI (`deps.edn`):
 
 ```clj
 net.clojars.savya/hier-set {:mvn/version "1.2.0"}
 ```
+
+## Usage
 
 Primary usage is then through the `hier-set` and `hier-set-by` constructor
 functions in the `hier-set.core` namespace.  In addition to set lookup as

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # hier-set
 
 [![Clojars Project](https://img.shields.io/clojars/v/net.clojars.savya/hier-set.svg)](https://clojars.org/net.clojars.savya/hier-set)
+[![cljdoc](https://cljdoc.org/badge/net.clojars.savya/hier-set)](https://cljdoc.org/d/net.clojars.savya/hier-set/CURRENT)
 [![test](https://github.com/jsavyasachi/hier-set/actions/workflows/test.yml/badge.svg)](https://github.com/jsavyasachi/hier-set/actions/workflows/test.yml)
 
 Library providing a "hierarchical set" data structure.  The provided data

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ A trivial example:
 
 Copyright © 2012, 2014 Marshall Bockrath-Vandegrift.
 
-Maintenance fork (2026) by Savyasachi, preserving the original Eclipse Public
-License.  Original project: https://github.com/llasram/hier-set
+Maintenance fork (2026) by Savyasachi, original: https://github.com/llasram/hier-set.
+Distributed under the [Eclipse Public License 1.0](https://www.eclipse.org/legal/epl-v10.html), preserving the original license.
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # hier-set
 
+[![Clojars Project](https://img.shields.io/clojars/v/net.clojars.savya/hier-set.svg)](https://clojars.org/net.clojars.savya/hier-set)
 [![test](https://github.com/jsavyasachi/hier-set/actions/workflows/test.yml/badge.svg)](https://github.com/jsavyasachi/hier-set/actions/workflows/test.yml)
 
 Library providing a "hierarchical set" data structure.  The provided data

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # hier-set
 
+[![test](https://github.com/jsavyasachi/hier-set/actions/workflows/test.yml/badge.svg)](https://github.com/jsavyasachi/hier-set/actions/workflows/test.yml)
+
 Library providing a "hierarchical set" data structure.  The provided data
 structure is set of elements with a defined hierarchical relationship.  An
 element is considered to be in the set either if it is provided as a primary
@@ -26,7 +28,7 @@ Add `hier-set` to the `:dependencies` list in your
 [Leiningen](https://github.com/technomancy/leiningen) `project.clj`:
 
 ```clj
-[hier-set "1.1.2"]
+[hier-set "1.2.0"]
 ```
 
 Primary usage is then through the `hier-set` and `hier-set-by` constructor
@@ -34,6 +36,11 @@ functions in the `hier-set.core` namespace.  In addition to set lookup as
 described above, the `hier-set.core/ancestors` and `hier-set.core/descendants`
 functions also provide access to lazy sequences of the ancestors and
 descendants respectively of a provided key.
+
+## Compatibility
+
+Requires Clojure 1.10 or later and JDK 8 or later.  Continuously tested against
+Clojure 1.10.3, 1.11.4, and 1.12.5 on JDK 8, 11, 17, and 21.
 
 ## Example
 
@@ -59,6 +66,9 @@ A trivial example:
 ## License
 
 Copyright © 2012, 2014 Marshall Bockrath-Vandegrift.
+
+Maintenance fork (2026) by Savyasachi, preserving the original Eclipse Public
+License.  Original project: https://github.com/llasram/hier-set
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported versions
+
+This is a community-maintained library. Security fixes are applied to the
+**latest released version** on Clojars. Please upgrade to the latest release
+before reporting an issue.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, report them privately by email to **jsavyasachi@gmail.com**, or via
+GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+("Report a vulnerability" under the repository's **Security** tab).
+
+Please include:
+
+- a description of the issue and its impact,
+- steps to reproduce (or a proof of concept), and
+- the affected version(s).
+
+You can expect an initial acknowledgement within a reasonable time. Once the
+issue is confirmed and a fix is released, the advisory will be published with
+credit to the reporter unless you request otherwise.

--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,6 @@
   :min-lein-version "2.9.0"
   :pedantic? :warn
   :global-vars {*warn-on-reflection* true}
-  :deploy-repositories [["clojars" {:url "https://repo.clojars.org"
-                                    :sign-releases false}]]
   :dependencies [[org.clojure/clojure "1.12.5"]]
   :aliases {"all" ["with-profile" ~(str "+clojure-1-10:"
                                         "+clojure-1-11:"

--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,18 @@
-(defproject hier-set "1.2.0-SNAPSHOT"
+(defproject hier-set "1.2.0"
   :description "A Clojure hierarchical set."
-  :url "http://github.com/llasram/hier-set"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :url "https://github.com/jsavyasachi/hier-set"
+  :license {:name "Eclipse Public License 1.0"
+            :url "https://www.eclipse.org/legal/epl-v10.html"}
+  :min-lein-version "2.9.0"
+  :pedantic? :warn
   :global-vars {*warn-on-reflection* true}
-  :dependencies [[org.clojure/clojure "1.6.0"]]
-  :aliases {"all" ["with-profile" ~(str "+clojure-1-4:"
-                                        "+clojure-1-5:"
-                                        "+clojure-1-6")]}
-  :profiles {:clojure-1-4 {:dependencies
-                           [[org.clojure/clojure "1.4.0"]]}
-             :clojure-1-5 {:dependencies
-                           [[org.clojure/clojure "1.5.1"]]}
-             :clojure-1-6 {:dependencies
-                           [[org.clojure/clojure "1.6.0"]]}})
+  :dependencies [[org.clojure/clojure "1.12.5"]]
+  :aliases {"all" ["with-profile" ~(str "+clojure-1-10:"
+                                        "+clojure-1-11:"
+                                        "+clojure-1-12")]}
+  :profiles {:clojure-1-10 {:dependencies
+                            [[org.clojure/clojure "1.10.3"]]}
+             :clojure-1-11 {:dependencies
+                            [[org.clojure/clojure "1.11.4"]]}
+             :clojure-1-12 {:dependencies
+                            [[org.clojure/clojure "1.12.5"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.jsavyasachi/hier-set "1.2.0"
+(defproject net.clojars.savya/hier-set "1.2.0"
   :description "A Clojure hierarchical set."
   :url "https://github.com/jsavyasachi/hier-set"
   :license {:name "Eclipse Public License 1.0"

--- a/project.clj
+++ b/project.clj
@@ -15,4 +15,8 @@
              :clojure-1-11 {:dependencies
                             [[org.clojure/clojure "1.11.4"]]}
              :clojure-1-12 {:dependencies
-                            [[org.clojure/clojure "1.12.5"]]}})
+                            [[org.clojure/clojure "1.12.5"]]}}
+  :deploy-repositories [["clojars" {:url "https://repo.clojars.org"
+                                    :username :env/clojars_username
+                                    :password :env/clojars_password
+                                    :sign-releases false}]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hier-set "1.2.0"
+(defproject io.github.jsavyasachi/hier-set "1.2.0"
   :description "A Clojure hierarchical set."
   :url "https://github.com/jsavyasachi/hier-set"
   :license {:name "Eclipse Public License 1.0"
@@ -6,6 +6,8 @@
   :min-lein-version "2.9.0"
   :pedantic? :warn
   :global-vars {*warn-on-reflection* true}
+  :deploy-repositories [["clojars" {:url "https://repo.clojars.org"
+                                    :sign-releases false}]]
   :dependencies [[org.clojure/clojure "1.12.5"]]
   :aliases {"all" ["with-profile" ~(str "+clojure-1-10:"
                                         "+clojure-1-11:"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.savya/hier-set "1.2.0"
+(defproject net.clojars.savya/hier-set "1.2.1"
   :description "A Clojure hierarchical set."
   :url "https://github.com/jsavyasachi/hier-set"
   :license {:name "Eclipse Public License 1.0"

--- a/src/hier_set/core.clj
+++ b/src/hier_set/core.clj
@@ -29,7 +29,7 @@ include `key` if `strict?` is true, defaulting to false."))
 
   Object
   (toString [this] (str contents))
-  (hashCode [this] (hash contents))
+  (hashCode [this] (.hashCode contents))
   (equals [this other]
     (.equals contents other))
 

--- a/src/hier_set/core.clj
+++ b/src/hier_set/core.clj
@@ -2,7 +2,7 @@
   "Provides a 'hierarchical set' data structure.  See `hier-set` for details."
   (:refer-clojure :exclude [descendants ancestors])
   (:import [java.util Set])
-  (:import [clojure.lang IFn ILookup IObj IPersistentCollection IPersistentSet
+  (:import [clojure.lang IFn IObj IPersistentCollection IPersistentSet
                          PersistentTreeSet Seqable Sorted]))
 
 (defprotocol Hierarchical

--- a/src/hier_set/core.clj
+++ b/src/hier_set/core.clj
@@ -89,7 +89,7 @@ include `key` if `strict?` is true, defaulting to false."))
   (iterator [this] (.iterator contents))
   (size [this] (.size contents))
   (toArray [this] (.toArray contents))
-  (toArray [this a] (.toArray contents a))
+  (^objects toArray [this ^objects a] (.toArray contents a))
 
   Sorted
   (comparator [this] (.comparator contents))

--- a/test/hier_set/core_test.clj
+++ b/test/hier_set/core_test.clj
@@ -89,3 +89,80 @@
           (is (= '("adam.nested.deeply" "adam.nested" "adam")
                  (get orig test-key)))
           (is (= '("adam.nested.deeply" "adam") (get updated test-key))))))))
+
+(deftest test-not-found-semantics
+  ;; Pins the behavior that `get`/invoke honor a not-found default. This is the
+  ;; guard that lets the dead `ILookup` import be removed without regression: if
+  ;; `valAt` were ever (mis)implemented, these would change.
+  (let [hs (hier-set with-starts? "foo" "foo.bar")]
+    (testing "not-found is returned for non-descendants"
+      (is (= :missing (get hs "nope" :missing)))
+      (is (= :missing (hs "nope" :missing))))
+    (testing "members ignore not-found and return their ancestors"
+      (is (= '("foo") (get hs "foo.baz" :missing)))
+      (is (= '("foo") (hs "foo.baz" :missing))))))
+
+(deftest test-hier-set-by
+  ;; `hier-set` delegates to `hier-set-by` with `compare`; exercise the latter
+  ;; directly and confirm sorted ordering is honored.
+  (let [hs (hier-set-by with-starts? compare "foo" "foo.bar" "quux")]
+    (testing "behaves like hier-set"
+      (is (= '("foo") (get hs "foo.baz")))
+      (is (= '("foo.bar" "foo") (get hs "foo.bar.x"))))
+    (testing "members are held in comparator order"
+      (is (= '("foo" "foo.bar" "quux") (seq hs))))))
+
+(deftest test-metadata
+  (let [hs  (hier-set with-starts? "foo" "foo.bar")
+        hs2 (with-meta hs {:a 1})]
+    (testing "metadata roundtrips via IObj"
+      (is (nil? (meta hs)))
+      (is (= {:a 1} (meta hs2))))
+    (testing "with-meta preserves contents"
+      (is (= (seq hs) (seq hs2)))
+      (is (= '("foo") (get hs2 "foo.baz"))))))
+
+(deftest test-collection-ops
+  (let [hs (hier-set with-starts? "foo" "foo.bar" "quux")]
+    (testing "count"
+      (is (= 3 (count hs))))
+    (testing "empty returns an empty hier-set"
+      (is (= 0 (count (empty hs))))
+      (is (empty? (empty hs))))
+    (testing "seq yields ascending members"
+      (is (= '("foo" "foo.bar" "quux") (seq hs))))))
+
+(deftest test-java-set-interop
+  (let [^java.util.Set hs (hier-set with-starts? "foo" "foo.bar" "quux")]
+    (testing "size / isEmpty"
+      (is (= 3 (.size hs)))
+      (is (false? (.isEmpty hs)))
+      (is (true? (.isEmpty ^java.util.Set (hier-set with-starts?)))))
+    (testing "iterator yields ascending members"
+      (is (= '("foo" "foo.bar" "quux") (iterator-seq (.iterator hs)))))
+    (testing "toArray (no-arg) and toArray(T[]) both return all members"
+      ;; The 2-arg form is the regression guard for the JDK 11+ toArray fix.
+      (is (= #{"foo" "foo.bar" "quux"} (set (.toArray hs))))
+      (is (= #{"foo" "foo.bar" "quux"} (set (.toArray hs ^objects (make-array Object 0))))))
+    (testing "containsAll"
+      (is (true? (.containsAll hs ["foo" "quux"])))
+      (is (false? (.containsAll hs ["foo" "nope"]))))))
+
+(deftest test-sorted-protocol
+  (let [^clojure.lang.Sorted hs (hier-set with-starts? "a" "b" "c" "d")]
+    (testing "comparator is exposed"
+      (is (some? (.comparator hs))))
+    (testing "seq honors direction"
+      (is (= '("a" "b" "c" "d") (seq (.seq hs true))))
+      (is (= '("d" "c" "b" "a") (seq (.seq hs false)))))
+    (testing "seqFrom starts at the key"
+      (is (= '("b" "c" "d") (seq (.seqFrom hs "b" true))))
+      (is (= '("b" "a") (seq (.seqFrom hs "b" false)))))))
+
+(deftest test-immutability
+  ;; The java.util.Set mutators are intentionally not implemented; calling them
+  ;; throws. Documents that a HierSet is immutable through the Set interface.
+  (let [^java.util.Set hs (hier-set with-starts? "foo")]
+    (is (thrown? AbstractMethodError (.add hs "x")))
+    (is (thrown? AbstractMethodError (.remove hs "foo")))
+    (is (thrown? AbstractMethodError (.clear hs)))))

--- a/test/hier_set/core_test.clj
+++ b/test/hier_set/core_test.clj
@@ -159,6 +159,14 @@
       (is (= '("b" "c" "d") (seq (.seqFrom hs "b" true))))
       (is (= '("b" "a") (seq (.seqFrom hs "b" false)))))))
 
+(deftest test-set-hashcode-contract
+  ;; java.util.Set requires hashCode to equal the sum of the members' hash
+  ;; codes, so an equal HashSet must hash identically.
+  (let [hs  (hier-set with-starts? "foo" "bar" "baz")
+        ref (java.util.HashSet. ["foo" "bar" "baz"])]
+    (is (= hs ref))
+    (is (= (.hashCode ^java.util.Set hs) (.hashCode ref)))))
+
 (deftest test-immutability
   ;; The java.util.Set mutators are intentionally not implemented; calling them
   ;; throws. Documents that a HierSet is immutable through the Set interface.


### PR DESCRIPTION
`master` stopped compiling on JDK 11+: Java 11 added `Collection.toArray(IntFunction)`, making the deftype's single-arg `toArray` overload ambiguous ("Must hint overloaded method: toArray"). Hinting it as `Object[]` fixes it. Last built on JDK 8.

Also:
- **fix:** `hashCode` now sums member hashes per the `java.util.Set` contract (was Clojure's collection hash, so an equal `HashSet` hashed differently)
- **build:** Clojure 1.12.5 default; profiles 1.10.3/1.11.4/1.12.5 (were 1.4/1.5/1.6); add `:min-lein-version`, `:pedantic? :warn`
- **refactor:** drop unused `ILookup` import
- **test:** 30 -> 63 assertions
- **ci:** GitHub Actions matrix, JDK 8/11/17/21 x Clojure 1.10.3/1.11.4/1.12.5
- **docs:** README + CHANGES.md

No API changes. CI green: https://github.com/jsavyasachi/hier-set/actions/runs/26996221544

README badge and `project.clj` `:url` point at my fork; can repoint to yours on merge.